### PR TITLE
Fix game `initialize` return value

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -10,7 +10,7 @@ void initialize(const char *appname, const char *appversion, const char *appiden
   if (!SDL_Init(SDL_INIT_VIDEO))
   {
     SDL_Log("Couldn't initialize SDL: %s", SDL_GetError());
-    return SDL_APP_FAILURE;
+    exit(2);
   }
 }
 


### PR DESCRIPTION
exit instead of return int

```c

void initialize(const char *appname, const char *appversion, const char *appidentifier)
{
  SDL_SetAppMetadata("Jump & Survive", "1.0", "com.c5.jump-and-survive");

  if (!SDL_Init(SDL_INIT_VIDEO))
  {
    SDL_Log("Couldn't initialize SDL: %s", SDL_GetError());
    exit(2);
  }
}
```