### PR TITLE
feat: add background music to levels

### DIFF
--- a/assets/levels/example.jsonc
+++ b/assets/levels/example.jsonc
@@ -25,6 +25,9 @@
 
   // background: string
   "background_image": "",
+
+  // bgm: string
+  "background_music": "",
   
   // tipe: array of objek
   // cek level.c -> change_level()

--- a/include/level.h
+++ b/include/level.h
@@ -24,6 +24,7 @@ struct LevelNode
   SDL_Color background_color;
 
   char bg_image[32];
+  char bg_music[32];
 
   Switch switches[100];
   Switch_Obstacles switch_obstacles[100];

--- a/src/level_parser.c
+++ b/src/level_parser.c
@@ -100,6 +100,11 @@ void set_bg_image_from_json(LevelNode *node, cJSON *json)
   strcpy(node->bg_image, json->valuestring);
 }
 
+void set_bg_music_from_json(LevelNode *node, cJSON *json)
+{
+  strcpy(node->bg_music, json->valuestring);
+}
+
 void set_switches_from_json(LevelNode *node, cJSON *json)
 {
   int i = 0;                                   // counter
@@ -259,6 +264,7 @@ LevelNode *get_level_from_json(const char *json_str)
       set_fg_color_from_json_array,
       set_bg_color_from_json_array,
       set_bg_image_from_json,
+      set_bg_music_from_json,
       set_switches_from_json,
       set_switch_obstacles_from_json,
       set_saws_from_json,


### PR DESCRIPTION
Adds background music functionality to levels.
Includes parsing from JSON and storage in LevelNode.